### PR TITLE
 Move deps to merged master from temp 2.2.5 dev 

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
 ]}.
 
 {deps, [
-    {protobuffs, "0.9.*", {git, "https://github.com/basho/erlang_protobuffs.git", {tag, "0.9.0"}}},
+    {protobuffs, "0.9.*", {git, "https://github.com/nhs-riak/erlang_protobuffs.git", {branch, "rdb/0.9.0-nhs-2.2.5"}}},
     {hamcrest, "0.3.*", {git, "https://github.com/basho/hamcrest-erlang.git", {tag, "0.3.0-basho"}}}
 ]}.
 

--- a/rebar.config
+++ b/rebar.config
@@ -6,7 +6,7 @@
 ]}.
 
 {deps, [
-    {protobuffs, "0.9.*", {git, "https://github.com/nhs-riak/erlang_protobuffs.git", {branch, "rdb/0.9.0-nhs-2.2.5"}}},
+    {protobuffs, "0.9.*", {git, "https://github.com/nhs-riak/erlang_protobuffs.git", {branch, "master"}}},
     {hamcrest, "0.3.*", {git, "https://github.com/basho/hamcrest-erlang.git", {tag, "0.3.0-basho"}}}
 ]}.
 


### PR DESCRIPTION
As part of setting up for the 2.2.5 release I made a temp branch off the
last released tag, this takes that branch back into the branch the tag
was cut from.