### PR TITLE
Add `node_confirms` option to write messages

### DIFF
--- a/src/riak_dt.proto
+++ b/src/riak_dt.proto
@@ -253,6 +253,7 @@ message DtUpdateReq {
     optional bool   sloppy_quorum   = 11;  // Experimental, may change/disappear
     optional uint32 n_val           = 12;  // Experimental, may change/disappear
     optional bool   include_context = 13 [default=true]; // When return_body is true, should the context be returned too?
+    optional uint32 node_confirms = 14; // Distinct phycical node quorum
 }
 
 

--- a/src/riak_kv.proto
+++ b/src/riak_kv.proto
@@ -86,6 +86,7 @@ message RpbPutReq {
     optional bool sloppy_quorum = 14; // Experimental, may change/disappear
     optional uint32 n_val = 15;       // Experimental, may change/disappear
     optional bytes type = 16;         // Bucket type, if not set we assume the 'default' type
+    optional uint32 node_confirms = 17; // Distinct phycical node quorum
 }
 
 // Put response - same as get response with optional key if one was generated
@@ -264,6 +265,7 @@ message RpbCounterUpdateReq {
     optional uint32 dw = 5;
     optional uint32 pw = 6;
     optional bool returnvalue = 7;
+    optional uint32 node_confirms = 8; // Distinct phycical node quorum
 }
 
 // Counter update response? No message | error response

--- a/src/riak_pb_dt_codec.erl
+++ b/src/riak_pb_dt_codec.erl
@@ -491,6 +491,8 @@ encode_update_options(Update, [{dw,DW}|Tail]) ->
     encode_update_options(Update#dtupdatereq{dw=encode_quorum(DW)},Tail);
 encode_update_options(Update, [{pw,PW}|Tail]) ->
     encode_update_options(Update#dtupdatereq{pw=encode_quorum(PW)},Tail);
+encode_update_options(Update, [{node_confirms,NodeConfirms}|Tail]) ->
+    encode_update_options(Update#dtupdatereq{node_confirms=encode_quorum(NodeConfirms)},Tail);
 encode_update_options(Update, [return_body|Tail]) ->
     encode_update_options(Update, [{return_body, true}|Tail]);
 encode_update_options(Update, [{return_body, RB}|Tail]) ->


### PR DESCRIPTION
For  KV/counter/datatypes all

(Needed by https://github.com/nhs-riak/riak_kv/pull/8)